### PR TITLE
link against gurobi*_light.so for gurobi>801

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -112,7 +112,14 @@ else
     GUROBI_ARGS=""
     GUROBI_ARGS="${GUROBI_ARGS} -DWITH_GUROBI=ON"
     GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_ROOT_DIR=${GUROBI_ROOT_DIR}"
-    GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_LIBRARY=$(ls ${GUROBI_ROOT_DIR}/lib/libgurobi*.so)"
+    # since gurobi 801, there is a _light lib included, which we can link agains:
+    if ls ${GUROBI_ROOT_DIR}/lib/libgurobi*_light.so 1> /dev/null 2>&1; then
+        # Gurobi >= 801
+        GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_LIBRARY=$(ls ${GUROBI_ROOT_DIR}/lib/libgurobi*_light.so)"
+    else
+        # Gurobi < 801
+        GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_LIBRARY=$(ls ${GUROBI_ROOT_DIR}/lib/libgurobi.so)"
+    fi
     GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_INCLUDE_DIR=${GUROBI_ROOT_DIR}/include"
     
     if [ $(uname) == "Darwin" ]; then    


### PR DESCRIPTION
fixes build on mac and linux
since gurobi 801 a light version of the gurobi lib is supplied

from gurobi website:

libgurobi80.so - Gurobi native library (used by all interfaces)
libgurobi80_light.so - light Gurobi native library (no support for Compute Server or Instant Cloud)

so I assume it is safe to link against this one